### PR TITLE
Many fixes to accommodate the new TEI generated by script from cvs fi…

### DIFF
--- a/code/bps/services/build.properties
+++ b/code/bps/services/build.properties
@@ -23,6 +23,8 @@ catalina.hostname=localhost
 catalina.base=${jee.dir}
 catalina.context.bps=${jee.dir}/conf/${catalina.engine}/${catalina.hostname}/${bps.services.context}.xml
 
+catalina.logdir=${env.BPS_JEESERVER_LOGS}
+
 db.base.dir=${jee.server.bps}/bps/services/db
 
 #For mysql, uncomment this, and comment out postgres section

--- a/code/bps/services/common/src/main/java/edu/berkeley/bps/services/common/time/TimeUtils.java
+++ b/code/bps/services/common/src/main/java/edu/berkeley/bps/services/common/time/TimeUtils.java
@@ -2,13 +2,19 @@ package edu.berkeley.bps.services.common.time;
 
 import java.util.Date;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class TimeUtils {
+	static final Logger logger = LoggerFactory.getLogger(TimeUtils.class);
 	private static GregorianCalendar cal = new GregorianCalendar();
 	private static SimpleDateFormat simpleYearFormatter = new SimpleDateFormat("y GG");
+	private static SimpleDateFormat simpleISODateFormatter = new SimpleDateFormat("yyyy-MM-dd GGG");
 	private static StringBuilder out = new StringBuilder(8);
 
 	public static final long DAY_IN_MILLIS = 24L*60L*60L*1000L;
@@ -28,6 +34,18 @@ public class TimeUtils {
 	 */
 	public static long getTimeInMillisForYear(int year) {
         return getTimeInMillisForYMD(year, Calendar.JULY, 1);
+	}
+
+	/**
+	 * @param dateString a standard ISO yyyy-mm-dd string with an optional era suffix
+	 * @return standard milliseconds from epoch
+	 * @throws ParseException 
+	 */
+	public static long parseISO_G_DateToMillis(String dateString) throws ParseException {
+		Date parsed = simpleISODateFormatter.parse(dateString);
+        cal.clear();
+		cal.setTime(parsed);
+	    return cal.getTimeInMillis();
 	}
 
 	/**

--- a/code/bps/services/common/src/main/java/edu/berkeley/bps/services/common/utils/StringStack.java
+++ b/code/bps/services/common/src/main/java/edu/berkeley/bps/services/common/utils/StringStack.java
@@ -2,6 +2,10 @@ package edu.berkeley.bps.services.common.utils;
 
 import java.util.ArrayList;
 
+/**
+ * @author pschmitz
+ *
+ */
 public class StringStack extends ArrayList<String> {
 	public static final String WILDCARD = "*";
 	public static final String ROOT_RELATIVE = ".";
@@ -31,7 +35,16 @@ public class StringStack extends ArrayList<String> {
 	}
 
 	public String peek() {
-		return get(size() - 1);
+		return peek(1);
+	}
+	
+	/**
+	 * Get the indicated String looking from the top of the stack. 
+	 * @param offset
+	 * @return
+	 */
+	public String peek(int offset) {
+		return get(size() - offset);
 	}
 	
 	public boolean matches(String[] path) {

--- a/code/bps/services/corpus/src/main/java/edu/berkeley/bps/services/corpus/Corpus.java
+++ b/code/bps/services/corpus/src/main/java/edu/berkeley/bps/services/corpus/Corpus.java
@@ -635,8 +635,8 @@ public class Corpus extends CachedEntity {
 	
 	@XmlElement(name="medianDocDate")
 	public String getMedianDocumentDateStr() {
-		long medianDate = getMedianDocumentDate();
-		return (medianDate==0)?null:
+		long medianDate = getMedianDocumentDate();  // BUG? There is a reasonable date at 0, in theory...
+		return (medianDate==0)?"":					// Return empty string instead of null
 			TimeUtils.millisToSimpleYearString(medianDate);
 	}
 	

--- a/code/bps/services/corpus/src/main/java/edu/berkeley/bps/services/corpus/TEI_Constants.java
+++ b/code/bps/services/corpus/src/main/java/edu/berkeley/bps/services/corpus/TEI_Constants.java
@@ -14,12 +14,22 @@ public class TEI_Constants {
 	public static final String PERSNAME_EL = "persName";
 	public static final String FORENAME_EL = "forename";
 	public static final String ADDNAME_EL = "addName";
+	public static final String STATE_EL = "state";
+
 
 	public static final String XMLID_ATTR = "xml:id";
 	public static final String TYPE_ATTR = "type";
+	public static final String SUBTYPE_ATTR = "subtype";
+	public static final String NYMREF_ATTR = "nymref";
+	public static final String N_ATTR = "n";			// Generic proper name as attribute
+	public static final String ROLE_ATTR = "role";
+
+	public static final String GENDER_TYPE_VAL = "gender";
 
 	public static final String TYPE_GENDER_MASCULINE = "masculine";
 	public static final String TYPE_GENDER_FEMININE = "feminine";
+	public static final String TYPE_GENDER_MALE = "male";
+	public static final String TYPE_GENDER_FEMALE = "female";
 	public static final String TYPE_GENDER_UNMARKED = "unmarked";
 	public static final String TYPE_PATRONYMIC = "patronymic";
 	public static final String TYPE_CLAN = "clan";

--- a/code/bps/services/webapp/src/main/resources/log4j.properties
+++ b/code/bps/services/webapp/src/main/resources/log4j.properties
@@ -24,7 +24,7 @@ log4j.appender.error.Threshold=WARN
 # The "bps_appender" appender - the standard BPS services log file appender
 #
 log4j.appender.bps_appender=org.apache.log4j.RollingFileAppender
-log4j.appender.bps_appender.File=${catalina.base}/logs/bps-services.log
+log4j.appender.bps_appender.File=${catalina.logdir}/bps-services.log
 log4j.appender.bps_appender.MaxFileSize=5000KB
 # Keep ten backup files
 log4j.appender.bps_appender.MaxBackupIndex=10

--- a/webcontent/src/main/resources/config.php
+++ b/webcontent/src/main/resources/config.php
@@ -56,7 +56,11 @@ $CFG->prefix    = '';        // Prefix to use for all table names (not working y
 //
 // Do not include a trailing slash!
 
-$CFG->wwwroot   = 'http://'.$_SERVER['SERVER_NAME'];
+$CFG->wwwroot   = 'http://'.$_SERVER['HTTP_HOST'];
+
+// When we are on a vm that maps ports, the above root is from the browser, and
+// this is from the server side. 
+$CFG->serverwwwroot   = 'http://'.$_SERVER['SERVER_NAME'];
 
 
 //=========================================================================

--- a/webcontent/src/main/resources/modules/corpora/corpora.php
+++ b/webcontent/src/main/resources/modules/corpora/corpora.php
@@ -219,7 +219,7 @@ GET ALL CORPORA IN SYSTEM
 **********************************/
 
 $rest = new RESTclient();
-$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/";
+$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/";
 $rest->createRequest($url,"GET");
 // Get the results in JSON for easier manipulation
 $rest->setJSONMode();
@@ -243,10 +243,10 @@ if($rest->sendRequest()) {
 	$opmsg = $rest->getError();
 }
 
-if($corpora)
+if(!empty($corpora))
 	$t->assign('corpora', $corpora);
-else if($ServCorpOutput != "")
-	$t->assign('opmsg', $ServCorpOutput);
+else if(!empty($ServCorpOutput)&&($ServCorpOutput!="[]"))
+	$t->assign('opmsg', $ServCorpOutput."(URL:".$url.")");
 
 if(isset($opmsg))
 	$t->assign('opmsg', $opmsg);

--- a/webcontent/src/main/resources/modules/corpora/corpus.php
+++ b/webcontent/src/main/resources/modules/corpora/corpus.php
@@ -234,7 +234,7 @@ function getCorpus($CFG,$id){
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/".$id;
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$id;
 	$rest->createRequest($url,"GET");
 	// Get the results in JSON for easier manipulation
 	$rest->setJSONMode();
@@ -262,7 +262,7 @@ function getCorpusDocs($CFG,$cid,$nid,$role,$order,$medianDocDate) {
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/".$cid."/documents";
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$cid."/documents";
 	$qch = "?";
 	if(!empty($nid)) {
 		$url .= "?name=".$nid;
@@ -309,7 +309,7 @@ function getNameInCorpus($CFG,$cid, $nid) {
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/".$cid."/names/".$nid;
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$cid."/names/".$nid;
 	$rest->createRequest($url,"GET");
 	// Get the results in JSON for easier manipulation
 	$rest->setJSONMode();
@@ -332,7 +332,7 @@ function getCorpusNames($CFG,$id,$roleFilter,$genderFilter,$typeFilter,$orderBy)
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/".$id."/names";
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$id."/names";
 	$first = true;
 	if(!empty($typeFilter)) {
 		$url .= "?type=".$typeFilter;
@@ -377,7 +377,7 @@ function getCorpusRoles($CFG,$cid){
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/".$cid."/activityRoles";
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$cid."/activityRoles";
 	$rest->createRequest($url,"GET");
 	// Get the results in JSON for easier manipulation
 	$rest->setJSONMode();

--- a/webcontent/src/main/resources/modules/corpora/document.php
+++ b/webcontent/src/main/resources/modules/corpora/document.php
@@ -41,7 +41,7 @@ $opmsg = false;
 unset($errmsg);
 
 function getDocUrl($CFG,$cid,$did){
-	return $CFG->wwwroot.$CFG->svcsbase."/corpora/".$cid."/documents/".$did;
+	return $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$cid."/documents/".$did;
 }
 
 function getDocNRADsUrl($CFG,$cid,$did){
@@ -52,7 +52,7 @@ function getCorpusMediaDocDate($CFG,$id){
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/".$id;
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$id;
 	$rest->createRequest($url,"GET");
 	// Get the results in JSON for easier manipulation
 	$rest->setJSONMode();
@@ -118,17 +118,17 @@ function getDocNRADs($CFG,$cid,$did){
 			$nradObj = &$result['nameRoleActivity'];
 			$nrad = array(	
 				'id' => $nradObj['id'],
-			  'xmlId' => isset($nradObj['xmlID'])?($nradObj['xmlID']):null,
-			 	'nameId' => isset($nradObj['nameId'])?($nradObj['nameId']):null, 
-			 	'name' => isset($nradObj['name'])?($nradObj['name']):null, 
-			 	'normalNameId' => isset($nradObj['normalNameId'])?($nradObj['normalNameId']):null, 
-			 	'normalName' => isset($nradObj['normalName'])?($nradObj['normalName']):null, 
-			 	'activityRoleId' => isset($nradObj['activityRoleId'])?($nradObj['activityRoleId']):null, 
-			 	'activityRole' => isset($nradObj['activityRole'])?($nradObj['activityRole']):null, 
+				'xmlId' => isset($nradObj['xmlID'])?($nradObj['xmlID']):null,
+				'nameId' => isset($nradObj['nameId'])?($nradObj['nameId']):null, 
+				'name' => isset($nradObj['name'])?($nradObj['name']):null, 
+				'normalNameId' => isset($nradObj['normalNameId'])?($nradObj['normalNameId']):null, 
+				'normalName' => isset($nradObj['normalName'])?($nradObj['normalName']):null, 
+				'activityRoleId' => isset($nradObj['activityRoleId'])?($nradObj['activityRoleId']):null, 
+				'activityRole' => isset($nradObj['activityRole'])?($nradObj['activityRole']):null, 
 				'activityRoleIsFamily' => (isset($nradObj['activityRoleIsFamily'])
 																	&&($nradObj['activityRoleIsFamily']=='true')), 
-			 	'activityId' => isset($nradObj['activityId'])?($nradObj['activityId']):null, 
-			 	'activity' => isset($nradObj['activity'])?($nradObj['activity']):null 
+				'activityId' => isset($nradObj['activityId'])?($nradObj['activityId']):null, 
+				'activity' => isset($nradObj['activity'])?($nradObj['activity']):null 
 			);
 			array_push($nrads, $nrad);
 			// Supposed to help with efficiency (dangling refs?)

--- a/webcontent/src/main/resources/modules/workspaces/document.php
+++ b/webcontent/src/main/resources/modules/workspaces/document.php
@@ -43,7 +43,7 @@ $opmsg = false;
 unset($errmsg);
 
 function getDocUrl($CFG,$wid,$did){
-	return $CFG->wwwroot.$CFG->svcsbase."/workspaces/".$wid."/documents/".$did;
+	return $CFG->serverwwwroot.$CFG->svcsbase."/workspaces/".$wid."/documents/".$did;
 }
 
 function getDocNRADsUrl($CFG,$wid,$did){
@@ -54,7 +54,7 @@ function getWorkspaceMedianDocDate($CFG,$id){
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/".$id;
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/".$id;
 	$rest->createRequest($url,"GET");
 	// Get the results in JSON for easier manipulation
 	$rest->setJSONMode();
@@ -121,16 +121,17 @@ function getDocNRADs($CFG,$wid,$did,$linkListMap){
 			$nradId = $nradObj['id'];
 			$nrads[] = array(	
 				'id' => $nradObj['id'],
-			  'xmlId' => $nradObj['xmlID'],
-			 	'nameId' => $nradObj['nameId'], 
-			 	'name' => $nradObj['name'], 
-			 	'normalNameId' => $nradObj['normalNameId'], 
-			 	'normalName' => $nradObj['normalName'], 
-			 	'activityRoleId' => $nradObj['activityRoleId'], 
-			 	'activityRole' => $nradObj['activityRole'], 
-			 	'activityRoleIsFamily' => ($nradObj['activityRoleIsFamily']=='true'), 
-			 	'activityId' => $nradObj['activityId'], 
-			 	'activity' => $nradObj['activity'],
+				'xmlId' => isset($nradObj['xmlID'])?($nradObj['xmlID']):null,
+				'nameId' => isset($nradObj['nameId'])?($nradObj['nameId']):null, 
+				'name' => isset($nradObj['name'])?($nradObj['name']):null, 
+				'normalNameId' => isset($nradObj['normalNameId'])?($nradObj['normalNameId']):null, 
+				'normalName' => isset($nradObj['normalName'])?($nradObj['normalName']):null, 
+				'activityRoleId' => isset($nradObj['activityRoleId'])?($nradObj['activityRoleId']):null, 
+				'activityRole' => isset($nradObj['activityRole'])?($nradObj['activityRole']):null, 
+				'activityRoleIsFamily' => (isset($nradObj['activityRoleIsFamily'])
+																	&&($nradObj['activityRoleIsFamily']=='true')), 
+				'activityId' => isset($nradObj['activityId'])?($nradObj['activityId']):null, 
+				'activity' => isset($nradObj['activity'])?($nradObj['activity']):null ,
 			 	'links' => $linkListMap[$nradId]
 			);
 			// Supposed to help with efficiency (dangling refs?)

--- a/webcontent/src/main/resources/modules/workspaces/workspace.php
+++ b/webcontent/src/main/resources/modules/workspaces/workspace.php
@@ -215,7 +215,7 @@ function getWorkspace($CFG,$user_id, $wkspid){
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/workspaces";
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/workspaces";
 	if(isset($wkspid)) {
 		$url = $url."/".$wkspid;
 	} else {
@@ -267,7 +267,7 @@ function getWorkspaceDocs($CFG,$id,$order,$medianDocDate) {
 	global $opmsg;
 
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/workspaces/".$id."/documents";
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/workspaces/".$id."/documents";
 	if(!empty($order))
 		$url .= "?o=".$order;
 	$rest->createRequest($url,"GET");
@@ -304,7 +304,7 @@ function getCorpora($CFG) {
 	global $opmsg;
 	
 	$rest = new RESTclient();
-	$url = $CFG->wwwroot.$CFG->svcsbase."/corpora/";
+	$url = $CFG->serverwwwroot.$CFG->svcsbase."/corpora/";
 	$rest->createRequest($url,"GET");
 	// Get the results in JSON for easier manipulation
 	$rest->setJSONMode();


### PR DESCRIPTION
…les. Now handles activity types, role declarations on persNames, gender marked either on the forename element or in state@gender attributes.

Added support for parsing more ISO-like dates, with era specifiers, and handled date declarations in the TEI.
Made more use of constants for TEI parsing (too many ugly string constants in the code).
Also fixed some old-style PHP to properly check for nulls and unset variables and indices.
Changed config.php to handle port-mapped environments.
Updated some php files to use port-mapped or local references to URLs.
Added support for a java log base-dir from the environment, rather than assuming logs are under catalina.base.