### PR TITLE
Fixed rounding error in the normalization of EntityLinkSet weight shi…

### DIFF
--- a/code/bps/services/workspace/src/main/java/edu/berkeley/bps/services/workspace/EntityLinkSet.java
+++ b/code/bps/services/workspace/src/main/java/edu/berkeley/bps/services/workspace/EntityLinkSet.java
@@ -94,7 +94,7 @@ public class EntityLinkSet<O> extends HashMap<Entity, EntityLink<O>> {
 		for(EntityLink<O> link:values()) {
 			calcSum += link.getWeight();
 		}
-		if(calcSum!=summedWeight)
+		if(Math.abs(calcSum-summedWeight) > 0.001)
 			throw new RuntimeException("Summed weight: "+summedWeight
 					+" != calculated sum: "+calcSum);
 


### PR DESCRIPTION
…fting. Was getting exceptions when the summed weight was 0.99999999999 and should have been 1. Sigh. Allowed for slight offset in verifySummedWeight().